### PR TITLE
메뉴창 높이 100%로 맞춤

### DIFF
--- a/src/components/layout/Menu.tsx
+++ b/src/components/layout/Menu.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled.div<{isOpen: boolean}>`
     height: calc(100% - 60px);
     background-color: white;
 
-    margin-top: 60px;
+    padding-top: 60px;
 
     z-index: 100;
 

--- a/src/layout/LayoutWrapper.tsx
+++ b/src/layout/LayoutWrapper.tsx
@@ -18,7 +18,7 @@ const LayoutWrapper: React.FC<Props> = ({children, isWhite}) => {
 
     return (
         <>
-            <Header isWhite={isWhite} setIsOpen={setIsOpen} />
+            <Header isWhite={isWhite && !isOpen} setIsOpen={setIsOpen} />
             <Menu isOpen={isOpen} />
             <InnerWrapper>{children}</InnerWrapper>
         </>


### PR DESCRIPTION
header가 투명할 때 생기던 문제 해결

header의 색을 메뉴가 열렸을 때 검정으로 보이도록 구성